### PR TITLE
fixed host callback parameter type causing a crash on x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Note from Beklemeto:
+Tested to work under visual studio for x86 and x64. Added a sample project.
+
 # About the Project
 This is a completely "clean room" untainted reverse engineered "SDK" for the VST 2.x interface. It was reverse engineered from binaries where no license restricting the reverse engineering was attached, or where the legal system explicitly allowed reverse engineering for the purpose of interoperability.
 

--- a/example/EmptyVst.cpp
+++ b/example/EmptyVst.cpp
@@ -1,0 +1,91 @@
+#include "EmptyVst.h"
+
+vstbase* createPlugin(vst_host_callback_t callback)
+{
+	return new EmptyVst(callback);
+}
+
+EmptyVst::EmptyVst(vst_host_callback_t callback) : vstbase(callback)
+{
+	effect.num_inputs = ChannelsCount;
+	effect.num_outputs = ChannelsCount;
+	effect.unique_id = VST_FOURCC('E', 'M', 'P', 'T');
+	product = "description about the plugin";
+	vendor = "Beklemeto";
+	name = "EmptyVst";
+	category = VST_EFFECT_CATEGORY_METERING;
+	version = 101;
+}
+
+void EmptyVst::processReplacing(const float* const* inputs, float** outputs, int32_t samples)
+{
+	int chanCount = ChannelsCount; 
+
+	for (int i = 0; i < chanCount; i++)
+	{
+		auto inputSamples = inputs[i];
+		auto outputSamples = outputs[i];
+
+		for (int j = 0; j < samples; j++)
+		{
+			outputSamples[j] = inputSamples[j] * 0.5f;
+		}
+	}
+}
+
+void EmptyVst::setSampleRate(float sampleRate)
+{ 
+	
+}
+
+bool EmptyVst::getSpeakerArrangement(vst_speaker_arrangement_t** pluginInput, vst_speaker_arrangement_t** pluginOutput)
+{
+	speakers.channels = ChannelsCount;
+	speakers.type = VST_SPEAKER_ARRANGEMENT_TYPE_STEREO;
+
+	*pluginInput = &speakers;
+	*pluginOutput = &speakers;
+
+	return true;
+}
+
+void EmptyVst::open()
+{
+}
+
+void EmptyVst::resume()
+{
+}
+
+void EmptyVst::suspend()
+{
+}
+
+void EmptyVst::close()
+{
+}
+
+EmptyVst::~EmptyVst()
+{
+}
+
+bool EmptyVst::editorOpen(void* parent)
+{	
+	return true;
+}
+
+void EmptyVst::editorClose()
+{
+}
+
+bool EmptyVst::editorRect(vst_rect_t** rect)
+{
+	*rect = &(this->rect);
+		
+	this->rect.top = 100;
+	this->rect.left = 100;
+	this->rect.bottom = 200;
+	this->rect.right = 300;
+			
+	return true;
+}

--- a/example/EmptyVst.h
+++ b/example/EmptyVst.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "..\include\vstbase.h"
+
+using namespace std;
+
+class EmptyVst : public vstbase
+{
+	static const int ChannelsCount = 2;
+
+	vst_speaker_arrangement_t speakers{0};
+	vst_rect_t rect{ 0 };
+
+public:
+    
+	EmptyVst(vst_host_callback_t callback);
+	~EmptyVst();
+
+	// Processing
+	virtual void processReplacing(const float* const* inputs, float** outputs, int32_t sampleFrames) override;
+	virtual void setSampleRate(float sampleRate) override;
+	virtual bool getSpeakerArrangement(vst_speaker_arrangement_t** pluginInput, vst_speaker_arrangement_t** pluginOutput) override;
+
+	// vst state
+	virtual void open() override;
+	virtual void close() override;
+	virtual void suspend() override;
+	virtual void resume() override;
+
+	// editor state
+	virtual bool editorOpen(void* parent) override;
+	virtual void editorClose() override;
+	virtual bool editorRect(vst_rect_t** rect) override;
+};

--- a/example/EmptyVst.sln
+++ b/example/EmptyVst.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.37111.16 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EmptyVst", "EmptyVst.vcxproj", "{1099F9FF-FC4F-468C-A88B-FD62FFD58712}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Debug|x64.ActiveCfg = Debug|x64
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Debug|x64.Build.0 = Debug|x64
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Debug|x86.ActiveCfg = Debug|Win32
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Debug|x86.Build.0 = Debug|Win32
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Release|x64.ActiveCfg = Release|x64
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Release|x64.Build.0 = Release|x64
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Release|x86.ActiveCfg = Release|Win32
+		{1099F9FF-FC4F-468C-A88B-FD62FFD58712}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DDC77D8C-E8ED-4144-B49D-A59AA7B0A91F}
+	EndGlobalSection
+EndGlobal

--- a/example/EmptyVst.vcxproj
+++ b/example/EmptyVst.vcxproj
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="EmptyVst.cpp" />
+    <ClCompile Include="vstmain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\vst.h" />
+    <ClInclude Include="..\include\vstbase.h" />
+    <ClInclude Include="EmptyVst.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{1099f9ff-fc4f-468c-a88b-fd62ffd58712}</ProjectGuid>
+    <RootNamespace>EmptyVst</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;EMPTYVST_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;EMPTYVST_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;EMPTYVST_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;EMPTYVST_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/example/EmptyVst.vcxproj.filters
+++ b/example/EmptyVst.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Files">
+      <UniqueIdentifier>{db44cb57-969f-434c-87a5-220744a535c6}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="EmptyVst.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
+    <ClCompile Include="vstmain.cpp">
+      <Filter>Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="EmptyVst.h">
+      <Filter>Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vstbase.h">
+      <Filter>Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vst.h">
+      <Filter>Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/example/vstmain.cpp
+++ b/example/vstmain.cpp
@@ -1,0 +1,34 @@
+#include <windows.h>
+
+#include "..\include\vstbase.h"
+
+
+extern vstbase* createPlugin(vst_host_callback_t callback);
+
+extern "C"
+{
+    static HINSTANCE hInstance = nullptr;
+
+    BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
+    {
+        if (reason == DLL_PROCESS_ATTACH)
+            hInstance = hInst;
+
+        return true;
+    }
+
+    __declspec(dllexport) VST_ENTRYPOINT
+    {
+        // old version
+        if (callback(nullptr, VST_HOST_OPCODE_01 /* version */, 0, 0, nullptr, 0.0f) == 0)
+            return nullptr;
+
+        vstbase* vstplugin = createPlugin(callback);
+        if (!vstplugin)
+            return nullptr;
+
+        return vstplugin->getEffect();
+    }
+}
+
+

--- a/include/vst.h
+++ b/include/vst.h
@@ -1584,7 +1584,7 @@ struct vst_host_supports_t {
  * @param p_str Zero terminated string or null on call.
  * @return ?
  */
-typedef intptr_t (VST_FUNCTION_INTERFACE *vst_host_callback_t)(struct vst_effect_t* plugin, int32_t opcode, int32_t p_int1, int64_t p_int2, const char* p_str, float p_float);
+typedef intptr_t (VST_FUNCTION_INTERFACE *vst_host_callback_t)(struct vst_effect_t* plugin, int32_t opcode, int32_t p_int1, intptr_t p_int2, const char* p_str, float p_float);
 
 //------------------------------------------------------------------------------------------------------------------------
 // VST Plug-in/Effect related Things

--- a/include/vstbase.h
+++ b/include/vstbase.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include "vst.h"
+#include <cstring>
+
+// using strcpy causes warning
+#pragma warning(disable : 4996)
+
+class vstbase
+{
+	const vst_host_callback_t host;
+
+protected:
+	vst_effect_t effect;
+
+    const char* product;
+    const char* vendor;
+    const char* name;
+    intptr_t version;
+    intptr_t category;
+
+public:
+	vstbase(vst_host_callback_t callback):host(callback)
+	{
+        memset(&effect, 0, sizeof(effect));
+
+        effect.magic_number = VST_MAGICNUMBER;
+        effect.unique_id = VST_FOURCC('T','E','S','T');
+        effect.version = VST_VERSION_2_4_0_0;
+        effect.num_params = 0;
+        effect.num_programs = 0;
+        effect.num_inputs = 0;
+        effect.num_outputs = 0;
+        effect.input_output_ratio = 1;
+        
+        // plugin flags
+        effect.flags |= VST_EFFECT_FLAG_SUPPORTS_FLOAT;
+        effect.flags |= VST_EFFECT_FLAG_EDITOR;
+        effect.flags |= VST_EFFECT_FLAG_CHUNKS;
+        //effect.flags |= VST_EFFECT_FLAG_SUPPORTS_DOUBLE;
+
+        // static calls
+        effect.control = &vst_control;
+        effect.process = &vst_process;
+        effect.get_parameter = &vst_getParameter;
+        effect.set_parameter = &vst_setParameter;
+        effect.process_float = &vst_processFloat;
+        effect.process_double = &vst_processDouble;
+        
+        // other
+        product = "Test";
+        vendor = "TestingCompany";
+        name = "TestVst";
+        category = VST_EFFECT_CATEGORY_METERING;
+        version = 0;
+
+        effect.effect_internal = this;  // important for the callbacks
+	}
+
+    vst_effect_t* getEffect()
+    {
+        return &effect;
+    }
+
+private:
+    //____________________________________________________________
+    //                     Effect Callbacks
+    //____________________________________________________________
+
+    static intptr_t VST_FUNCTION_INTERFACE vst_control(struct vst_effect_t* self, int32_t opcode, int32_t p_int1, intptr_t p_int2, void* p_ptr, float p_float)
+    {
+        return ((vstbase*)(self->effect_internal))->control(opcode, p_int1, p_int2, p_ptr, p_float);
+    }
+
+    static void VST_FUNCTION_INTERFACE vst_process(struct vst_effect_t* self, const float* const* inputs, float** outputs, int32_t samples)
+    {
+        //obsolete
+    }
+
+    static void VST_FUNCTION_INTERFACE vst_processFloat(struct vst_effect_t* self, const float* const* inputs, float** outputs, int32_t samples)
+    {
+        ((vstbase*)(self->effect_internal))->processReplacing(inputs, outputs, samples);
+    }
+
+    static void VST_FUNCTION_INTERFACE vst_processDouble(struct vst_effect_t* self, const double* const* inputs, double** outputs, int32_t samples)
+    {
+        ((vstbase*)(self->effect_internal))->processReplacingDouble(inputs, outputs, samples);
+    }
+
+    static float VST_FUNCTION_INTERFACE vst_getParameter(struct vst_effect_t* self, uint32_t index)
+    {
+        return ((vstbase*)(self->effect_internal))->getParameter(index);
+    }
+
+    static void VST_FUNCTION_INTERFACE vst_setParameter(struct vst_effect_t* self, uint32_t index, float value)
+    {
+        ((vstbase*)(self->effect_internal))->setParameter(index, value);
+    }
+
+    intptr_t VST_FUNCTION_INTERFACE control(int32_t opcode, int32_t p_int1, intptr_t p_int2, void* p_ptr, float p_float)
+    {
+        intptr_t ret = 0;
+
+        switch (opcode)
+        {
+        case VST_EFFECT_OPCODE_INITIALIZE:
+            open();
+            break;
+        case VST_EFFECT_OPCODE_DESTROY:
+            close();
+            break;
+        case VST_EFFECT_OPCODE_SET_PROGRAM:
+        case VST_EFFECT_OPCODE_GET_PROGRAM:
+        case VST_EFFECT_OPCODE_SET_PROGRAM_NAME:
+        case VST_EFFECT_OPCODE_GET_PROGRAM_NAME:
+        case VST_EFFECT_OPCODE_PARAM_GETLABEL:
+        case VST_EFFECT_OPCODE_PARAM_GETVALUE:
+        case VST_EFFECT_OPCODE_PARAM_GETNAME:
+        case VST_EFFECT_OPCODE_09:
+            break;
+
+        case VST_EFFECT_OPCODE_SETSAMPLERATE:
+            setSampleRate(p_float);
+            break;
+        case VST_EFFECT_OPCODE_SETBLOCKSIZE:
+            break;
+        case VST_EFFECT_OPCODE_SUSPEND_RESUME:
+            if (!p_int2) suspend(); else resume();
+            break;
+        case VST_EFFECT_OPCODE_EDITOR_GET_RECT:
+            ret = editorRect((vst_rect_t**)p_ptr);
+            break;
+        case VST_EFFECT_OPCODE_EDITOR_OPEN:
+            ret = editorOpen(p_ptr);
+            break;
+        case VST_EFFECT_OPCODE_EDITOR_CLOSE:
+            editorClose();
+            break;
+
+        case VST_EFFECT_OPCODE_EDITOR_DRAW:
+        case VST_EFFECT_OPCODE_EDITOR_MOUSE:
+        case VST_EFFECT_OPCODE_EDITOR_KEYBOARD:
+        case VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE:
+        case VST_EFFECT_OPCODE_14:
+        case VST_EFFECT_OPCODE_15:
+        case VST_EFFECT_OPCODE_FOURCC:
+        case VST_EFFECT_OPCODE_GET_CHUNK_DATA:
+        case VST_EFFECT_OPCODE_SET_CHUNK_DATA:
+        case VST_EFFECT_OPCODE_EVENT:
+        case VST_EFFECT_OPCODE_PARAM_AUTOMATABLE:
+        case VST_EFFECT_OPCODE_PARAM_SET_VALUE:
+        case VST_EFFECT_OPCODE_1C:
+        case VST_EFFECT_OPCODE_1D:
+        case VST_EFFECT_OPCODE_1E:
+        case VST_EFFECT_OPCODE_1F:
+        case VST_EFFECT_OPCODE_20:
+        case VST_EFFECT_OPCODE_INPUT_GET_PROPERTIES:
+        case VST_EFFECT_OPCODE_OUTPUT_GET_PROPERTIES:
+            break;
+
+        case VST_EFFECT_OPCODE_EFFECT_CATEGORY:
+            return category;
+
+        case VST_EFFECT_OPCODE_24:
+        case VST_EFFECT_OPCODE_25:
+        case VST_EFFECT_OPCODE_26:
+        case VST_EFFECT_OPCODE_27:
+        case VST_EFFECT_OPCODE_28:
+        case VST_EFFECT_OPCODE_29:
+        case VST_EFFECT_OPCODE_SET_SPEAKER_ARRANGEMENT:
+        case VST_EFFECT_OPCODE_2B:
+        case VST_EFFECT_OPCODE_BYPASS:
+            break;
+        case VST_EFFECT_OPCODE_EFFECT_NAME:
+            std::strcpy((char*)p_ptr, name);
+            return true;
+        case VST_EFFECT_OPCODE_TRANSLATE_ERROR:
+            break;
+        case VST_EFFECT_OPCODE_VENDOR_NAME:
+            std::strcpy((char*)p_ptr, vendor);
+            return true;
+        case VST_EFFECT_OPCODE_PRODUCT_NAME:
+            std::strcpy((char*)p_ptr, product);
+            return true;
+        case VST_EFFECT_OPCODE_VENDOR_VERSION:
+            return version;
+
+        case VST_EFFECT_OPCODE_CUSTOM:
+        case VST_EFFECT_OPCODE_SUPPORTS:
+        case VST_EFFECT_OPCODE_GETTAILSAMPLES:
+        case VST_EFFECT_OPCODE_IDLE:
+        case VST_EFFECT_OPCODE_36:
+        case VST_EFFECT_OPCODE_37:
+        case VST_EFFECT_OPCODE_PARAM_PROPERTIES:
+        case VST_EFFECT_OPCODE_39:
+            break;
+
+        case VST_EFFECT_OPCODE_VST_VERSION:
+            return VST_VERSION_2_4_0_0;
+
+        case VST_EFFECT_OPCODE_EDITOR_VKEY_DOWN:
+        case VST_EFFECT_OPCODE_EDITOR_VKEY_UP:
+        case VST_EFFECT_OPCODE_3D:
+        case VST_EFFECT_OPCODE_3E:
+        case VST_EFFECT_OPCODE_3F:
+        case VST_EFFECT_OPCODE_40:
+        case VST_EFFECT_OPCODE_41:
+        case VST_EFFECT_OPCODE_42:
+        case VST_EFFECT_OPCODE_PROGRAM_SET_BEGIN:
+        case VST_EFFECT_OPCODE_PROGRAM_SET_END:
+            break;
+
+        case VST_EFFECT_OPCODE_GET_SPEAKER_ARRANGEMENT:
+            ret = getSpeakerArrangement((vst_speaker_arrangement_t**)p_int2, (vst_speaker_arrangement_t**)p_ptr);
+            break;
+
+        case VST_EFFECT_OPCODE_CONTAINER_NEXT_EFFECT_ID:
+        case VST_EFFECT_OPCODE_PROCESS_BEGIN:
+        case VST_EFFECT_OPCODE_PROCESS_END:
+        case VST_EFFECT_OPCODE_49:
+        case VST_EFFECT_OPCODE_4A:
+        case VST_EFFECT_OPCODE_BANK_LOAD:
+        case VST_EFFECT_OPCODE_PROGRAM_LOAD:
+        case VST_EFFECT_OPCODE_4D:
+        case VST_EFFECT_OPCODE_4E:
+        case VST_EFFECT_OPCODE_4F:
+            break;
+        default:
+            break;
+        }
+
+
+        return ret;
+    }
+    
+    //____________________________________________________________
+    //                     VstBase Callbacks
+    //____________________________________________________________
+protected:
+
+    virtual void processReplacing(const float* const* inputs, float** outputs, int32_t samples) {};
+    virtual void processReplacingDouble(const double* const* inputs, double** outputs, int32_t samples) {};
+    virtual float getParameter(uint32_t index) { return 0; }
+    virtual void setParameter(uint32_t index, float value) {}
+    virtual void setSampleRate(float sampleRate) = 0;
+    virtual bool getSpeakerArrangement(vst_speaker_arrangement_t** pluginInput, vst_speaker_arrangement_t** pluginOutput) = 0;
+
+    virtual void open() = 0;
+    virtual void close() = 0;
+    virtual void suspend() = 0;
+    virtual void resume() = 0;
+
+    // editor state
+    virtual bool editorOpen(void* parent) = 0;
+    virtual void editorClose() = 0;
+    virtual bool editorRect(vst_rect_t** rect) = 0;
+
+};


### PR DESCRIPTION
The interface of vst_host_callback_t is similar to vst_effect_control_t, which is correctly using intptr and not int64.